### PR TITLE
Add deprecated notice in REAME

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 iOS Blank App
 =============
 
-> This template app is deprecated use [helloworld-ios-app](https://github.com/feedhenry-templates/helloworld-ios) instead.
+> This template app is deprecated use [helloworld-ios-app](https://github.com/feedhenry-templates/blank-ios-app) instead.
 
 
 iOS Blank app is a simple app to get you started with FH iOS sdk.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 iOS Blank App
 =============
-iOS Blank app is a simple app to get you started with FH iOS sdk.
 
+> This template app is deprecated use [helloworld-ios-app](https://github.com/feedhenry-templates/helloworld-ios) instead.
+
+
+iOS Blank app is a simple app to get you started with FH iOS sdk.
 
 You can scaffold this app either:
 - using RHMAP (Red Hat Mobile Application Platform) UI console.
-- or clone directly from this repository. If you clone it manually to make the app buildable in RHMAP Build Farm, replace the templaeing ```%id%``` in ```FHStarterProject\FHStarterProject-Info.plist``` in the following block:
+- or clone directly from this repository. If you clone it manually to make the app buildable in RHMAP Build Farm, replace the templating ```%id%``` in ```FHStarterProject\FHStarterProject-Info.plist``` in the following block:
 
 ```xml
 <key>CFBundleIdentifier</key>


### PR DESCRIPTION
As discussed in https://github.com/feedhenry-templates/helloworld-ios/pull/8
only one template app for cloud call is needed.

@edewit @secondsun @danielpassos 